### PR TITLE
Broke chatbot down into modules

### DIFF
--- a/botkit/index.js
+++ b/botkit/index.js
@@ -1,6 +1,5 @@
 var Botkit = require('botkit');
 var os = require('os');
-var rp = require('request-promise');
 
 if (!process.env.token) {
     console.log('Error: Specify token in environment');
@@ -34,167 +33,16 @@ var reply_with_attachments = {
   'icon_url': 'http://lorempixel.com/48/48'
 }
 
-controller.hears(['help'],
-    'direct_message,direct_mention,mention', function(bot, message) {
-        bot.reply(message, reply_with_attachments);
+/*
+    Include all chat bot modules here. Order matters.
+    Note the "wHIte stripes" bug
+*/
+addHandler(['help'], "help")
+addHandler(['call me (.*)', 'my name is (.*)'], "callme")
+addHandler(['wiki (.*)'], "wikipedia")
+addHandler(['uptime', 'identify yourself', 'who are you', 'what is your name'], "uptime")
+addHandler(['hello', 'hi'], "greetings")
 
-    });
-    
-
-controller.hears(['wiki (.*)'], 'direct_message,direct_mention,mention', function(bot, message) {
-    console.log(message)
-    console.log(message.match[1])
-    var search_term = encodeURIComponent(message.match[1]);
-    var url = `https://en.wikipedia.org/w/api.php?action=opensearch&search=${search_term}&limit=1&format=json`;
-    var options = {
-        uri: url,
-        json: true
-    };
-    rp(options)
-        .then(function (data) {
-            console.log(data[3][0])
-            bot.reply(message, data[3][0]);
-        })
-        .catch(function (err) {
-            console.log('error', err);
-        });
-});
-
-
-
-
-controller.hears(['call me (.*)', 'my name is (.*)'], 'direct_message,direct_mention,mention', function(bot, message) {
-    var name = message.match[1];
-    controller.storage.users.get(message.user, function(err, user) {
-        if (!user) {
-            user = {
-                id: message.user,
-            };
-        }
-        user.name = name;
-        controller.storage.users.save(user, function(err, id) {
-            bot.reply(message, 'Got it. I will call you ' + user.name + ' from now on.');
-        });
-    });
-});
-
-controller.hears(['what is my name', 'who am i'], 'direct_message,direct_mention,mention', function(bot, message) {
-
-    controller.storage.users.get(message.user, function(err, user) {
-        if (user && user.name) {
-            bot.reply(message, 'Your name is ' + user.name);
-        } else {
-            bot.startConversation(message, function(err, convo) {
-                if (!err) {
-                    convo.say('I do not know your name yet!');
-                    convo.ask('What should I call you?', function(response, convo) {
-                        convo.ask('You want me to call you `' + response.text + '`?', [
-                            {
-                                pattern: 'yes',
-                                callback: function(response, convo) {
-                                    // since no further messages are queued after this,
-                                    // the conversation will end naturally with status == 'completed'
-                                    convo.next();
-                                }
-                            },
-                            {
-                                pattern: 'no',
-                                callback: function(response, convo) {
-                                    // stop the conversation. this will cause it to end with status == 'stopped'
-                                    convo.stop();
-                                }
-                            },
-                            {
-                                default: true,
-                                callback: function(response, convo) {
-                                    convo.repeat();
-                                    convo.next();
-                                }
-                            }
-                        ]);
-
-                        convo.next();
-
-                    }, {'key': 'nickname'}); // store the results in a field called nickname
-
-                    convo.on('end', function(convo) {
-                        if (convo.status == 'completed') {
-                            bot.reply(message, 'OK! I will update my dossier...');
-
-                            controller.storage.users.get(message.user, function(err, user) {
-                                if (!user) {
-                                    user = {
-                                        id: message.user,
-                                    };
-                                }
-                                user.name = convo.extractResponse('nickname');
-                                controller.storage.users.save(user, function(err, id) {
-                                    bot.reply(message, 'Got it. I will call you ' + user.name + ' from now on.');
-                                });
-                            });
-
-
-
-                        } else {
-                            // this happens if the conversation ended prematurely for some reason
-                            bot.reply(message, 'OK, nevermind!');
-                        }
-                    });
-                }
-            });
-        }
-    });
-});
-
-controller.hears(['hello', 'hi'], 'direct_message,direct_mention,mention', function(bot, message) {
-
-    bot.api.reactions.add({
-        timestamp: message.ts,
-        channel: message.channel,
-        name: 'robot_face',
-    }, function(err, res) {
-        if (err) {
-            bot.botkit.log('Failed to add emoji reaction :(', err);
-        }
-    });
-
-
-    controller.storage.users.get(message.user, function(err, user) {
-        if (user && user.name) {
-            bot.reply(message, 'Hello ' + user.name + '!!');
-        } else {
-            bot.reply(message, 'Hello.');
-        }
-    });
-});
-
-controller.hears(['uptime', 'identify yourself', 'who are you', 'what is your name'],
-    'direct_message,direct_mention,mention', function(bot, message) {
-
-        var hostname = os.hostname();
-        var uptime = formatUptime(process.uptime());
-
-        bot.reply(message,
-            ':robot_face: I am a bot named <@' + bot.identity.name +
-            '>. I have been running for ' + uptime + ' on ' + hostname + '.');
-
-    });
-
-function formatUptime(uptime) {
-    var unit = 'second';
-    if (uptime > 60) {
-        uptime = uptime / 60;
-        unit = 'minute';
-    }
-    if (uptime > 60) {
-        uptime = uptime / 60;
-        unit = 'hour';
-    }
-    if (uptime != 1) {
-        unit = unit + 's';
-    }
-
-    uptime = uptime + ' ' + unit;
-    return uptime;
+function addHandler(handles, name){
+    require("./modules/" + name + ".js")(handles, controller, bot)
 }
-

--- a/botkit/modules/callme.js
+++ b/botkit/modules/callme.js
@@ -1,0 +1,16 @@
+module.exports = (handles, controller, bot) => {
+    controller.hears(handles, 'direct_message,direct_mention,mention', function (bot, message) {
+        var name = message.match[1];
+        controller.storage.users.get(message.user, function (err, user) {
+            if (!user) {
+                user = {
+                    id: message.user,
+                };
+            }
+            user.name = name;
+            controller.storage.users.save(user, function (err, id) {
+                bot.reply(message, 'Got it. I will call you ' + user.name + ' from now on.');
+            });
+        });
+    });
+}

--- a/botkit/modules/greetings.js
+++ b/botkit/modules/greetings.js
@@ -1,0 +1,23 @@
+module.exports = (handles, controller, bot) => {
+    controller.hears(handles, 'direct_message,direct_mention,mention', function (bot, message) {
+
+        bot.api.reactions.add({
+            timestamp: message.ts,
+            channel: message.channel,
+            name: 'robot_face',
+        }, function (err, res) {
+            if (err) {
+                bot.botkit.log('Failed to add emoji reaction :(', err);
+            }
+        });
+
+
+        controller.storage.users.get(message.user, function (err, user) {
+            if (user && user.name) {
+                bot.reply(message, 'Hello ' + user.name + '!!');
+            } else {
+                bot.reply(message, 'Hello.');
+            }
+        });
+    });
+}

--- a/botkit/modules/help.js
+++ b/botkit/modules/help.js
@@ -1,0 +1,7 @@
+module.exports = (handles, controller, bot) => {
+controller.hears(handles,
+    'direct_message,direct_mention,mention', function(bot, message) {
+        bot.reply(message, reply_with_attachments);
+
+    });
+}

--- a/botkit/modules/myname.js
+++ b/botkit/modules/myname.js
@@ -1,0 +1,69 @@
+module.exports = (handles, controller, bot) => {
+controller.hears(handles, 'direct_message,direct_mention,mention', function(bot, message) {
+
+    controller.storage.users.get(message.user, function(err, user) {
+        if (user && user.name) {
+            bot.reply(message, 'Your name is ' + user.name);
+        } else {
+            bot.startConversation(message, function(err, convo) {
+                if (!err) {
+                    convo.say('I do not know your name yet!');
+                    convo.ask('What should I call you?', function(response, convo) {
+                        convo.ask('You want me to call you `' + response.text + '`?', [
+                            {
+                                pattern: 'yes',
+                                callback: function(response, convo) {
+                                    // since no further messages are queued after this,
+                                    // the conversation will end naturally with status == 'completed'
+                                    convo.next();
+                                }
+                            },
+                            {
+                                pattern: 'no',
+                                callback: function(response, convo) {
+                                    // stop the conversation. this will cause it to end with status == 'stopped'
+                                    convo.stop();
+                                }
+                            },
+                            {
+                                default: true,
+                                callback: function(response, convo) {
+                                    convo.repeat();
+                                    convo.next();
+                                }
+                            }
+                        ]);
+
+                        convo.next();
+
+                    }, {'key': 'nickname'}); // store the results in a field called nickname
+
+                    convo.on('end', function(convo) {
+                        if (convo.status == 'completed') {
+                            bot.reply(message, 'OK! I will update my dossier...');
+
+                            controller.storage.users.get(message.user, function(err, user) {
+                                if (!user) {
+                                    user = {
+                                        id: message.user,
+                                    };
+                                }
+                                user.name = convo.extractResponse('nickname');
+                                controller.storage.users.save(user, function(err, id) {
+                                    bot.reply(message, 'Got it. I will call you ' + user.name + ' from now on.');
+                                });
+                            });
+
+
+
+                        } else {
+                            // this happens if the conversation ended prematurely for some reason
+                            bot.reply(message, 'OK, nevermind!');
+                        }
+                    });
+                }
+            });
+        }
+    });
+});
+}

--- a/botkit/modules/uptime.js
+++ b/botkit/modules/uptime.js
@@ -1,0 +1,32 @@
+module.exports = (handles, controller, bot) => {
+    controller.hears(handles,
+        'direct_message,direct_mention,mention', function (bot, message) {
+
+            var hostname = os.hostname();
+            var uptime = formatUptime(process.uptime());
+
+            bot.reply(message,
+                ':robot_face: I am a bot named <@' + bot.identity.name +
+                '>. I have been running for ' + uptime + ' on ' + hostname + '.');
+
+        });
+
+    function formatUptime(uptime) {
+        var unit = 'second';
+        if (uptime > 60) {
+            uptime = uptime / 60;
+            unit = 'minute';
+        }
+        if (uptime > 60) {
+            uptime = uptime / 60;
+            unit = 'hour';
+        }
+        if (uptime != 1) {
+            unit = unit + 's';
+        }
+
+        uptime = uptime + ' ' + unit;
+        return uptime;
+    }
+
+}

--- a/botkit/modules/wikipedia.js
+++ b/botkit/modules/wikipedia.js
@@ -1,0 +1,21 @@
+module.exports = (handles, controller, bot) => {
+    var rp = require('request-promise');
+    controller.hears(handles, 'direct_message,direct_mention,mention', function (bot, message) {
+        console.log(message)
+        console.log(message.match[1])
+        var search_term = encodeURIComponent(message.match[1]);
+        var url = `https://en.wikipedia.org/w/api.php?action=opensearch&search=${search_term}&limit=1&format=json`;
+        var options = {
+            uri: url,
+            json: true
+        };
+        rp(options)
+            .then(function (data) {
+                console.log(data[3][0])
+                bot.reply(message, data[3][0]);
+            })
+            .catch(function (err) {
+                console.log('error', err);
+            });
+    });
+}


### PR DESCRIPTION
In an effort to avoid conflicts, I broke down the chatbot commands into easily extensible modules.

In botkit folder, there is no an `index.js` which is the main controller and a `modules` folder.

The main controller can include handlers from the modules folder as well as hook them up to specific triggers.

Pros:
 - Easily extensible
 - Easier to isolate errors
 - Less chances of merge errors

Cons:
 - Code duplication
 - Increased level of abstraction
 - A single change in index.js may require modifications of each module